### PR TITLE
Publishing configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,3 +16,10 @@ uv pip install -e ".[test]"
 ```bash
 uv run pytest
 ```
+
+## Build & publish
+
+```bash
+uv build
+uv publish
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,20 @@
 [project]
-name = "a5-py"
+name = "pya5"
 version = "0.1.0"
 description = "A5 - Global Pentagonal Geospatial Index"
 readme = "README.md"
 requires-python = ">=3.8"
+license = {file = 'LICENSE'}
 dependencies = [
     "numpy>=1.24.0"
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["a5"]
 
 [project.optional-dependencies]
 test = ["pytest>=7.0.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -8,28 +8,6 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "a5-py"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
-    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
-    { name = "numpy", version = "2.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-]
-
-[package.optional-dependencies]
-test = [
-    { name = "pytest" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "numpy", specifier = ">=1.24.0" },
-    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
-]
-provides-extras = ["test"]
-
-[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -250,6 +228,28 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
+
+[[package]]
+name = "pya5"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "numpy", version = "1.24.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "numpy", version = "2.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+    { name = "numpy", version = "2.2.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "numpy", specifier = ">=1.24.0" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=7.0.0" },
+]
+provides-extras = ["test"]
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
### Background

Changes required to enable packaging and publishing to Pypi

### Changes

- `a5py` and `a5` already exist on Pypi, use `pya5` (for now)
- Build configuration that works with Pypi and `uv`